### PR TITLE
chore: use [bot] prefix for created issue titles

### DIFF
--- a/.github/workflows/agent-automation.yml
+++ b/.github/workflows/agent-automation.yml
@@ -129,7 +129,7 @@ jobs:
             - Create at most ${{ matrix.max_issues }} issues in this run.
             - Create one issue per distinct gap.
             - Keep each issue concise, concrete, and source-backed.
-            - Prefix every created issue title with `[BOT ISSUE] `.
+            - Prefix every created issue title with `[bot] `.
             - If the repository supports issue types, choose whichever type fits best (`Bug`, `Feature`, or `Task`). If issue types are unavailable, create the issue without type.
             - Include a hidden marker comment near the top of the issue body in this exact form:
 

--- a/.github/workflows/library-gap-audit.yml
+++ b/.github/workflows/library-gap-audit.yml
@@ -130,7 +130,7 @@ jobs:
             - Create at most ${{ matrix.max_issues }} issues in this run.
             - Create one issue per distinct library gap.
             - Keep each issue concise, concrete, and source-backed.
-            - Prefix every created issue title with `[BOT ISSUE] `.
+            - Prefix every created issue title with `[bot] `.
             - If the repository supports issue types, choose whichever type fits best (`Bug`, `Feature`, or `Task`). If issue types are unavailable, create the issue without type.
             - Include a hidden marker comment near the top of the issue body in this exact form:
 


### PR DESCRIPTION
`[BOT ISSUE]` seems too much for our repos. Hopefully this makes our issues stream a bit easier to parse, both for us and external contributors.