### PR TITLE
feat: Clarify braintrust repo privacy assumption

### DIFF
--- a/.github/workflows/braintrust-security-audit.yml
+++ b/.github/workflows/braintrust-security-audit.yml
@@ -71,6 +71,7 @@ jobs:
             - Inspect only the checked-out source repository for source-code, configuration, dependency, infrastructure-as-code, authentication, authorization, data exposure, injection, tenant isolation, cryptography, secret handling, webhook, API, and deployment security issues.
             - Assume `SOURCE_REPO_OWNER/SOURCE_REPO_NAME` is private. Other repositories in the GitHub organization may not be private.
             - Focus on vulnerabilities with a concrete affected code path, configuration, or dependency and a plausible exploit or abuse path.
+            - Prioritize reporting vulnerabilities with the highest realistic likelihood of occurring in production and the highest impact if exploited.
             - Treat tests, docs, examples, generated files, and scripts as supporting evidence, but do not report findings that only affect non-production examples unless they create a realistic production risk.
             - Exclude speculative hardening ideas, broad best-practice suggestions, style issues, missing tests without a vulnerability, and purely theoretical issues without repo evidence.
             - Do not report secret-scanning alerts or raw leaked secrets. If you encounter a secret-looking value in source, describe only the file/path and risk class without including the secret value.

--- a/.github/workflows/braintrust-security-audit.yml
+++ b/.github/workflows/braintrust-security-audit.yml
@@ -69,6 +69,7 @@ jobs:
             # Scope
 
             - Inspect only the checked-out source repository for source-code, configuration, dependency, infrastructure-as-code, authentication, authorization, data exposure, injection, tenant isolation, cryptography, secret handling, webhook, API, and deployment security issues.
+            - Assume `SOURCE_REPO_OWNER/SOURCE_REPO_NAME` is private. Other repositories in the GitHub organization may not be private.
             - Focus on vulnerabilities with a concrete affected code path, configuration, or dependency and a plausible exploit or abuse path.
             - Treat tests, docs, examples, generated files, and scripts as supporting evidence, but do not report findings that only affect non-production examples unless they create a realistic production risk.
             - Exclude speculative hardening ideas, broad best-practice suggestions, style issues, missing tests without a vulnerability, and purely theoretical issues without repo evidence.

--- a/.github/workflows/braintrust-security-audit.yml
+++ b/.github/workflows/braintrust-security-audit.yml
@@ -71,7 +71,7 @@ jobs:
             - Inspect only the checked-out source repository for source-code, configuration, dependency, infrastructure-as-code, authentication, authorization, data exposure, injection, tenant isolation, cryptography, secret handling, webhook, API, and deployment security issues.
             - Assume `SOURCE_REPO_OWNER/SOURCE_REPO_NAME` is private. Other repositories in the GitHub organization may not be private.
             - Focus on vulnerabilities with a concrete affected code path, configuration, or dependency and a plausible exploit or abuse path.
-            - Prioritize reporting vulnerabilities with the highest realistic likelihood of occurring in production and the highest impact if exploited.
+            - Prioritize reporting vulnerabilities with the highest realistic likelihood of discovery by an attacker and the highest impact if exploited.
             - Treat tests, docs, examples, generated files, and scripts as supporting evidence, but do not report findings that only affect non-production examples unless they create a realistic production risk.
             - Exclude speculative hardening ideas, broad best-practice suggestions, style issues, missing tests without a vulnerability, and purely theoretical issues without repo evidence.
             - Do not report secret-scanning alerts or raw leaked secrets. If you encounter a secret-looking value in source, describe only the file/path and risk class without including the secret value.

--- a/.github/workflows/braintrust-security-audit.yml
+++ b/.github/workflows/braintrust-security-audit.yml
@@ -72,6 +72,7 @@ jobs:
             - Assume `SOURCE_REPO_OWNER/SOURCE_REPO_NAME` is private. Other repositories in the GitHub organization may not be private.
             - Focus on vulnerabilities with a concrete affected code path, configuration, or dependency and a plausible exploit or abuse path.
             - Prioritize reporting vulnerabilities with the highest realistic likelihood of discovery by an attacker and the highest impact if exploited.
+            - Pay particular attention to user-provided AI provider secrets and API keys. Trace concrete code paths where they are accepted, propagated, logged, stored, cached, or sent to providers, and prioritize findings where they are exposed in plaintext outside the minimum required execution path, persisted or cached in plaintext, or spread to components that do not need them.
             - Treat tests, docs, examples, generated files, and scripts as supporting evidence, but do not report findings that only affect non-production examples unless they create a realistic production risk.
             - Exclude speculative hardening ideas, broad best-practice suggestions, style issues, missing tests without a vulnerability, and purely theoretical issues without repo evidence.
             - Do not report secret-scanning alerts or raw leaked secrets. If you encounter a secret-looking value in source, describe only the file/path and risk class without including the secret value.


### PR DESCRIPTION
## Summary

Adds an explicit scope assumption to the Braintrust security audit prompt that the checked-out braintrust repository is private.

Clarifies that other repositories in the GitHub organization may not be private, so the security scan should not generalize the privacy assumption org-wide.

## Validation

Reviewed `git diff origin/main...`; this is a prompt-only workflow change, so no automated tests were run.