### PR TITLE
Fix Ruby release actions

### DIFF
--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -52,6 +52,13 @@ on:
         description: "Commit SHA (of the version bump) to release"
         required: true
         type: string
+      prev_release:
+        description: "Anchor for release notes: a tag name or commit SHA. If SHA, notes will be empty."
+        type: string
+        required: false
+        # bt-fake: fixed SHA anchor prevents indefinite changelog accumulation.
+        # Update this when you want to reset the notes baseline.
+        default: '58a397193105516446c3042361913655bcece509'
       dry_run:
         description: "Dry run: Build without tagging or publishing"
         type: boolean
@@ -79,7 +86,7 @@ jobs:
       contents: read
     outputs:
       release_tag: ${{ steps.validate-release.outputs.release_tag }}
-      prev_tag: ${{ steps.validate-release.outputs.prev_tag }}
+      prev_release: ${{ steps.validate-release.outputs.prev_release }}
       branch: ${{ steps.validate-release.outputs.branch }}
       on_release_branch: ${{ steps.validate-release.outputs.on_release_branch }}
       commit_message: ${{ steps.validate-release.outputs.commit_message }}
@@ -133,7 +140,7 @@ jobs:
         with:
           release_tag: ${{ needs.validate.outputs.release_tag }}
           sha: ${{ inputs.sha }}
-          prev_tag: ${{ needs.validate.outputs.prev_tag }}
+          prev_release: ${{ inputs.prev_release || needs.validate.outputs.prev_release }}
 
   notify-pending:
     needs: [validate, prepare]
@@ -149,7 +156,7 @@ jobs:
         with:
           sha: ${{ inputs.sha }}
           release_tag: ${{ needs.validate.outputs.release_tag }}
-          prev_tag: ${{ needs.validate.outputs.prev_tag }}
+          prev_release: ${{ needs.validate.outputs.prev_release }}
           branch: ${{ needs.validate.outputs.branch }}
           on_release_branch: ${{ needs.validate.outputs.on_release_branch }}
           commit_message: ${{ needs.validate.outputs.commit_message }}
@@ -158,6 +165,7 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack_channel: ${{ vars.SLACK_SDK_RELEASE_CHANNEL }}
+          emoji: ':ruby:'
 
   publish:
     needs: [bump, validate, prepare, notify-pending]
@@ -173,14 +181,16 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0
 
-      # bt-fake: write the run-number version into version.rb before building.
-      # The publish job checks out fresh, so version.rb still has the placeholder.
-      # Real SDK workflows omit this — version.rb is already correct from the bump PR.
-      - name: Apply version to version.rb
+      # bt-fake: update both version.rb and Gemfile.lock to the run-number version.
+      # The publish job checks out fresh so both files still reflect the placeholder.
+      # Real SDK workflows omit this — both files are committed together in the bump PR.
+      - name: Apply version to version.rb and Gemfile.lock
         run: |
           VERSION="${{ needs.bump.outputs.version }}"
           sed -i "s|VERSION = \".*\"|VERSION = \"$VERSION\"|" \
             test/release/ruby/lib/bt_fake/version.rb
+          sed -i "s|bt-fake ([0-9]*\.[0-9]*\.[0-9]*)|bt-fake ($VERSION)|" \
+            test/release/ruby/Gemfile.lock
 
       # Update working-directory to your gem's root
       - name: Publish gem
@@ -203,10 +213,11 @@ jobs:
         uses: ./actions/release/notify-published
         with:
           release_tag: ${{ needs.validate.outputs.release_tag }}
-          prev_tag: ${{ needs.validate.outputs.prev_tag }}
+          prev_release: ${{ needs.validate.outputs.prev_release }}
           branch: ${{ needs.validate.outputs.branch }}
           on_release_branch: ${{ needs.validate.outputs.on_release_branch }}
           pr_list: ${{ needs.prepare.outputs.pr_list }}
           dry_run: ${{ inputs.dry_run }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack_channel: ${{ vars.SLACK_SDK_RELEASE_CHANNEL }}
+          emoji: ':white_check_mark:'

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -122,6 +122,11 @@ jobs:
       pr_list: ${{ steps.prepare.outputs.pr_list }}
       notes: ${{ steps.prepare.outputs.notes }}
     steps:
+      # bt-fake: checkout required because actions are referenced locally (./actions/...).
+      # Real SDK workflows reference actions externally (braintrustdata/sdk-actions/...@sha)
+      # and do not need this step.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Prepare release
         id: prepare
         uses: ./actions/release/prepare
@@ -136,6 +141,9 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     steps:
+      # bt-fake: checkout required for local action resolution (see prepare job comment)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Notify release pending
         uses: ./actions/release/notify-pending
         with:
@@ -181,13 +189,15 @@ jobs:
           working-directory: test/release/ruby
           dry_run: ${{ inputs.dry_run }}
 
-      - name: Create GitHub release
-        uses: ./actions/release/create-github-release
-        with:
-          release_tag: ${{ needs.validate.outputs.release_tag }}
-          sha: ${{ inputs.sha }}
-          notes: ${{ needs.prepare.outputs.notes }}
-          dry_run: ${{ inputs.dry_run }}
+      # bt-fake: GitHub release creation disabled to avoid tag/release pollution
+      # from repeated test runs. In real SDK workflows, uncomment this step.
+      # - name: Create GitHub release
+      #   uses: ./actions/release/create-github-release
+      #   with:
+      #     release_tag: ${{ needs.validate.outputs.release_tag }}
+      #     sha: ${{ inputs.sha }}
+      #     notes: ${{ needs.prepare.outputs.notes }}
+      #     dry_run: ${{ inputs.dry_run }}
 
       - name: Notify release complete
         uses: ./actions/release/notify-published

--- a/actions/release/notify-pending/action.yml
+++ b/actions/release/notify-pending/action.yml
@@ -10,7 +10,7 @@ inputs:
   release_tag:
     description: "The release tag (e.g. v0.3.2)"
     required: true
-  prev_tag:
+  prev_release:
     description: "Previous release tag"
     required: false
     default: ''
@@ -84,9 +84,9 @@ runs:
         echo "**Commit:** $COMMIT_MSG" >> $GITHUB_STEP_SUMMARY
         echo "**Branch:** $BRANCH_LABEL" >> $GITHUB_STEP_SUMMARY
 
-        if [ -n "${{ inputs.prev_tag }}" ]; then
-          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${{ inputs.prev_tag }}...${{ inputs.sha }}"
-          echo "**Diff:** [${{ inputs.prev_tag }}...$TAG]($DIFF_URL)" >> $GITHUB_STEP_SUMMARY
+        if [ -n "${{ inputs.prev_release }}" ]; then
+          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${{ inputs.prev_release }}...${{ inputs.sha }}"
+          echo "**Diff:** [${{ inputs.prev_release }}...$TAG]($DIFF_URL)" >> $GITHUB_STEP_SUMMARY
         fi
 
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -115,9 +115,9 @@ runs:
         fi
 
         DIFF_PART=""
-        if [ -n "${{ inputs.prev_tag }}" ]; then
-          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${{ inputs.prev_tag }}...${{ inputs.sha }}"
-          DIFF_PART=" · <$DIFF_URL|${{ inputs.prev_tag }}...$TAG>"
+        if [ -n "${{ inputs.prev_release }}" ]; then
+          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${{ inputs.prev_release }}...${{ inputs.sha }}"
+          DIFF_PART=" · <$DIFF_URL|${{ inputs.prev_release }}...$TAG>"
         fi
 
         PR_LIST=$(echo "$PR_LIST_RAW" | tr $'\x1f' '\n' | sed '/^$/d')

--- a/actions/release/notify-published/action.yml
+++ b/actions/release/notify-published/action.yml
@@ -6,7 +6,7 @@ inputs:
   release_tag:
     description: "The release tag (e.g. v0.3.2)"
     required: true
-  prev_tag:
+  prev_release:
     description: "Previous release tag"
     required: false
     default: ''
@@ -57,9 +57,9 @@ runs:
         RELEASE_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/$TAG"
 
         DIFF_PART=""
-        if [ -n "${{ inputs.prev_tag }}" ]; then
-          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${{ inputs.prev_tag }}...$TAG"
-          DIFF_PART="<$DIFF_URL|${{ inputs.prev_tag }}...$TAG>  ·  "
+        if [ -n "${{ inputs.prev_release }}" ]; then
+          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${{ inputs.prev_release }}...$TAG"
+          DIFF_PART="<$DIFF_URL|${{ inputs.prev_release }}...$TAG>  ·  "
         fi
 
         PR_LIST=$(echo "$PR_LIST_RAW" | tr $'\x1f' '\n' | sed '/^$/d')

--- a/actions/release/prepare/action.yml
+++ b/actions/release/prepare/action.yml
@@ -10,8 +10,12 @@ inputs:
   sha:
     description: "The commit SHA being released"
     required: true
-  prev_tag:
-    description: "The previous release tag"
+  prev_release:
+    description: >
+      Anchor for release notes. Accepts a tag name or a full commit SHA.
+      If a tag: generates notes via the GitHub API using it as the previous release.
+      If a SHA: notes are unavailable (no reliable cross-strategy PR extraction);
+      outputs will be empty. If omitted, GitHub auto-detects the previous release.
     required: false
     default: ''
 
@@ -31,13 +35,21 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
+        PREV_RELEASE: ${{ inputs.prev_release }}
       run: |
-        PREV_TAG="${{ inputs.prev_tag }}"
+        # If prev_release is a full SHA, notes are unavailable
+        if echo "$PREV_RELEASE" | grep -qE '^[0-9a-f]{40}$'; then
+          echo "SHA provided for prev_release — notes unavailable for SHA ranges."
+          echo "pr_list=" >> $GITHUB_OUTPUT
+          echo "notes=$(echo "" | base64 -w 0)" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         BODY=$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
           --method POST \
           --field tag_name="${{ inputs.release_tag }}" \
           --field target_commitish="${{ inputs.sha }}" \
-          ${PREV_TAG:+--field previous_tag_name="$PREV_TAG"} \
+          ${PREV_RELEASE:+--field previous_tag_name="$PREV_RELEASE"} \
           --jq '.body' 2>/dev/null || echo "")
 
         PR_LIST=$(echo "$BODY" \

--- a/actions/release/validate/action.yml
+++ b/actions/release/validate/action.yml
@@ -14,6 +14,13 @@ inputs:
     description: "Skip tag existence failure in dry runs"
     required: false
     default: 'false'
+  tag_format:
+    description: >
+      Format string for the git tag. Use {version} as the placeholder.
+      Defaults to 'v{version}' (e.g. v0.3.2). Override for SDKs or test
+      packages with different conventions (e.g. 'py-sdk-v{version}').
+    required: false
+    default: 'v{version}'
   release_branch:
     description: >
       Branch name or glob pattern considered a valid release source.
@@ -54,7 +61,9 @@ runs:
       id: validate
       shell: bash
       run: |
-        TAG="v${{ inputs.version }}"
+        VERSION="${{ inputs.version }}"
+        TAG="${{ inputs.tag_format }}"
+        TAG="${TAG//\{version\}/$VERSION}"
         COMMIT_MSG=$(git log -1 --format="%s" HEAD)
         BRANCH=$(git branch -r --contains HEAD --format="%(refname:short)" | sed 's|origin/||' | head -1)
 

--- a/actions/release/validate/action.yml
+++ b/actions/release/validate/action.yml
@@ -33,9 +33,9 @@ outputs:
   release_tag:
     description: "The release tag (e.g. v0.3.2)"
     value: ${{ steps.validate.outputs.release_tag }}
-  prev_tag:
+  prev_release:
     description: "The previous release tag"
-    value: ${{ steps.validate.outputs.prev_tag }}
+    value: ${{ steps.validate.outputs.prev_release }}
   branch:
     description: "The branch containing the SHA"
     value: ${{ steps.validate.outputs.branch }}
@@ -86,11 +86,13 @@ runs:
           fi
         done
 
-        PREV_TAG=$(git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' HEAD^ 2>/dev/null || echo "")
+        PREV_RELEASE_PATTERN="${{ inputs.tag_format }}"
+        PREV_RELEASE_PATTERN="${PREV_RELEASE_PATTERN//\{version\}/[0-9]*.[0-9]*.[0-9]*}"
+        PREV_RELEASE=$(git describe --tags --abbrev=0 --match="$PREV_RELEASE_PATTERN" HEAD^ 2>/dev/null || echo "")
 
         echo "release_tag=$TAG" >> $GITHUB_OUTPUT
         echo "commit_message=$COMMIT_MSG" >> $GITHUB_OUTPUT
         echo "branch=$BRANCH" >> $GITHUB_OUTPUT
         echo "on_release_branch=$ON_RELEASE_BRANCH" >> $GITHUB_OUTPUT
-        echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+        echo "prev_release=$PREV_RELEASE" >> $GITHUB_OUTPUT
         echo "Validated $TAG @ ${{ inputs.sha }} ($COMMIT_MSG)"

--- a/test/release/ruby/Rakefile
+++ b/test/release/ruby/Rakefile
@@ -39,8 +39,8 @@ namespace :release do
 end
 
 # Called by rubygems/release-gem in the release workflow.
-# Follows Bundler convention: build, push gem, push tag.
-# GitHub release creation is handled separately by the workflow.
-task release: ["release:publish", "release:push_tag"] do
+# bt-fake: tag push omitted to avoid tag pollution from repeated test runs.
+# In real SDK workflows, include "release:push_tag" here.
+task release: ["release:publish"] do
   puts "✓ Release complete"
 end

--- a/test/release/ruby/Rakefile
+++ b/test/release/ruby/Rakefile
@@ -9,7 +9,10 @@ end
 
 desc "Build gem into pkg/"
 task :build do
-  sh "gem build bt-fake.gemspec --output pkg/bt-fake-$(ruby -r './lib/bt_fake/version' -e 'print BtFake::VERSION').gem"
+  require_relative "lib/bt_fake/version"
+  sh "gem build bt-fake.gemspec"
+  mkdir_p "pkg"
+  mv "bt-fake-#{BtFake::VERSION}.gem", "pkg/"
 end
 
 namespace :release do


### PR DESCRIPTION
Follow up to #41 . Get the release process working for Ruby. Some important changes:

1. Add a "Previous release" input: for generating correct release notes when last tag isn't the right one (e.g. beta releases between major/minor ones)
2. Make `tag_format`, `release_branch` configurable on `validate`
3. Get the Ruby `bt-fake` workflow working:
    - Fix broken `rake build`, version bumping side effects
    - Don't push tags/GitHub releases that would create a lot of pollution in this repo
    - Plumb in emojis (for identification)