### PR TITLE
More improvements for Ruby release process

### DIFF
--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -91,33 +91,23 @@ jobs:
       on_release_branch: ${{ steps.validate-release.outputs.on_release_branch }}
       commit_message: ${{ steps.validate-release.outputs.commit_message }}
     steps:
+      # bt-fake: checkout required to resolve local ./actions/... references.
+      # Real SDK workflows use external braintrustdata/sdk-actions/...@sha references
+      # and do not need this step.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.sha }}
-          fetch-depth: 0
-
-      # Update working-directory to your gem's root
-      - name: Set up language runtime
-        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
-        with:
-          ruby-version: '3.4'
-          bundler-cache: true
-          working-directory: test/release/ruby
-
-      # bt-fake: sources from the bump job instead of a version file.
-      # In a real Ruby project: replace with the path to your version.rb and module name.
-      # e.g. ruby -r "./lib/your_gem/version.rb" -e "puts YourGem::VERSION"
-      - name: Read version
-        id: read-version
-        run: echo "version=${{ needs.bump.outputs.version }}" >> $GITHUB_OUTPUT
 
       - name: Validate release
         id: validate-release
-        uses: ./actions/release/validate
+        uses: ./actions/release/lang/ruby/validate
         with:
-          version: ${{ steps.read-version.outputs.version }}
+          # bt-fake: version passed directly from bump job — no version file needed.
+          # In a real Ruby project, replace `version` with:
+          #   version_file: lib/your_gem/version.rb
+          #   version_module: YourGem
+          version: ${{ needs.bump.outputs.version }}
           sha: ${{ inputs.sha }}
           dry_run: ${{ inputs.dry_run }}
+          working_directory: test/release/ruby
 
   prepare:
     needs: validate
@@ -165,6 +155,7 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack_channel: ${{ vars.SLACK_SDK_RELEASE_CHANNEL }}
+          # slack_mention: '@sdk-eng'
           emoji: ':ruby:'
 
   publish:
@@ -185,8 +176,9 @@ jobs:
       # The publish job checks out fresh so both files still reflect the placeholder.
       # Real SDK workflows omit this — both files are committed together in the bump PR.
       - name: Apply version to version.rb and Gemfile.lock
+        env:
+          VERSION: ${{ needs.bump.outputs.version }}
         run: |
-          VERSION="${{ needs.bump.outputs.version }}"
           sed -i "s|VERSION = \".*\"|VERSION = \"$VERSION\"|" \
             test/release/ruby/lib/bt_fake/version.rb
           sed -i "s|bt-fake ([0-9]*\.[0-9]*\.[0-9]*)|bt-fake ($VERSION)|" \
@@ -194,10 +186,14 @@ jobs:
 
       # Update working-directory to your gem's root
       - name: Publish gem
-        uses: ./actions/release/ruby/publish
+        uses: ./actions/release/lang/ruby/publish
         with:
-          working-directory: test/release/ruby
+          working_directory: test/release/ruby
           dry_run: ${{ inputs.dry_run }}
+          release_tag: ${{ needs.validate.outputs.release_tag }}
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack_channel: ${{ vars.SLACK_SDK_RELEASE_CHANNEL }}
+          # slack_mention: '@sdk-eng'
 
       # bt-fake: GitHub release creation disabled to avoid tag/release pollution
       # from repeated test runs. In real SDK workflows, uncomment this step.
@@ -210,7 +206,7 @@ jobs:
       #     dry_run: ${{ inputs.dry_run }}
 
       - name: Notify release complete
-        uses: ./actions/release/notify-published
+        uses: ./actions/release/lang/ruby/notify-published
         with:
           release_tag: ${{ needs.validate.outputs.release_tag }}
           prev_release: ${{ needs.validate.outputs.prev_release }}
@@ -220,4 +216,5 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack_channel: ${{ vars.SLACK_SDK_RELEASE_CHANNEL }}
-          emoji: ':white_check_mark:'
+          # slack_mention: '@sdk-eng'
+          gem_name: bt-fake

--- a/actions/lang/ruby/env-dump/action.yml
+++ b/actions/lang/ruby/env-dump/action.yml
@@ -1,0 +1,27 @@
+name: Ruby Environment Dump
+description: >
+  Prints Ruby environment information useful for diagnosing failures —
+  Ruby version, bundler version, default gems, and lockfile metadata.
+  Default gems are shown because version conflicts with locked versions
+  cause bundler activation errors.
+
+inputs:
+  working_directory:
+    description: "Path to the gem root (where Gemfile.lock lives)"
+    required: false
+    default: '.'
+
+runs:
+  using: composite
+  steps:
+    - name: Dump Ruby environment
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        echo "=== Ruby environment ==="
+        ruby --version
+        bundle --version
+        echo "=== Default gems (version conflicts may cause activation errors) ==="
+        ruby -e "Gem::Specification.default_stubs.map { |s| \"#{s.name} #{s.version}\" }.sort.each { |g| puts g }"
+        echo "=== Gemfile.lock BUNDLED WITH ==="
+        grep -A1 "^BUNDLED WITH" Gemfile.lock 2>/dev/null || echo "(not found)"

--- a/actions/release/lang/ruby/notify-published/action.yml
+++ b/actions/release/lang/ruby/notify-published/action.yml
@@ -1,0 +1,74 @@
+name: Notify Ruby Gem Release Complete
+description: >
+  Ruby-specific wrapper around notify-published. Builds a links JSON array
+  containing the RubyGems entry, then delegates to the generic action.
+
+inputs:
+  release_tag:
+    description: "The release tag (e.g. v0.3.2)"
+    required: true
+  prev_release:
+    description: "Previous release tag"
+    required: false
+    default: ''
+  branch:
+    description: "Branch the release was made from"
+    required: true
+  on_release_branch:
+    description: "Whether the release was from an expected release branch"
+    required: true
+  pr_list:
+    description: "x1f-delimited PR list from prepare action"
+    required: false
+    default: ''
+  dry_run:
+    description: "Whether this was a dry run"
+    required: false
+    default: 'false'
+  slack_token:
+    description: "Slack bot token"
+    required: false
+    default: ''
+  slack_channel:
+    description: "Slack channel ID"
+    required: false
+    default: ''
+  emoji:
+    description: "Emoji prefix for Slack messages"
+    required: false
+    default: ':white_check_mark:'
+  gem_name:
+    description: "RubyGems gem name (e.g. braintrust). Used to build the RubyGems link."
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Build links
+      id: links
+      shell: bash
+      env:
+        GEM_NAME: ${{ inputs.gem_name }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+        DRY_RUN: ${{ inputs.dry_run }}
+      run: |
+        LINKS='[]'
+        if [ "$DRY_RUN" != "true" ] && [ -n "$GEM_NAME" ]; then
+          VERSION="${RELEASE_TAG#v}"
+          LINKS="[{\"label\":\"RubyGems\",\"url\":\"https://rubygems.org/gems/$GEM_NAME/versions/$VERSION\"}]"
+        fi
+        echo "links=$LINKS" >> $GITHUB_OUTPUT
+
+    - uses: ./actions/release/notify-published
+      with:
+        release_tag: ${{ inputs.release_tag }}
+        prev_release: ${{ inputs.prev_release }}
+        branch: ${{ inputs.branch }}
+        on_release_branch: ${{ inputs.on_release_branch }}
+        pr_list: ${{ inputs.pr_list }}
+        dry_run: ${{ inputs.dry_run }}
+        slack_token: ${{ inputs.slack_token }}
+        slack_channel: ${{ inputs.slack_channel }}
+        emoji: ${{ inputs.emoji }}
+        links: ${{ steps.links.outputs.links }}

--- a/actions/release/lang/ruby/on-failure/action.yml
+++ b/actions/release/lang/ruby/on-failure/action.yml
@@ -1,0 +1,43 @@
+name: Ruby Release Failure Handler
+description: >
+  Handles release failures for Ruby gems — dumps the Ruby environment for
+  diagnostics and sends a Slack failure notification.
+
+inputs:
+  release_tag:
+    description: "The release tag being attempted"
+    required: true
+  step:
+    description: "The step that failed (e.g. 'validate', 'publish')"
+    required: true
+  working_directory:
+    description: "Path to the gem root for environment diagnostics"
+    required: false
+    default: '.'
+  slack_token:
+    description: "Slack bot token"
+    required: false
+    default: ''
+  slack_channel:
+    description: "Slack channel ID"
+    required: false
+    default: ''
+  slack_mention:
+    description: "Optional Slack handle or group to notify"
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - uses: ./actions/lang/ruby/env-dump
+      with:
+        working_directory: ${{ inputs.working_directory }}
+
+    - uses: ./actions/release/notify-failure
+      with:
+        release_tag: ${{ inputs.release_tag }}
+        step: ${{ inputs.step }}
+        slack_token: ${{ inputs.slack_token }}
+        slack_channel: ${{ inputs.slack_channel }}
+        slack_mention: ${{ inputs.slack_mention }}

--- a/actions/release/lang/ruby/publish/action.yml
+++ b/actions/release/lang/ruby/publish/action.yml
@@ -5,18 +5,34 @@ description: >
   environment — set DRY_RUN=true to lint and build without pushing.
 
 inputs:
-  working-directory:
+  working_directory:
     description: "Path to the gem root (where the Gemfile and gemspec live)"
     required: false
     default: '.'
-  ruby-version:
-    description: "Ruby version to use (defaults to .ruby-version file if present)"
+  ruby_version:
+    description: "Ruby version to use"
     required: false
-    default: '3.4'
+    default: '4.0'
   dry_run:
     description: "Skip gem push and tag push"
     required: false
     default: 'false'
+  release_tag:
+    description: "The release tag — used in failure notifications"
+    required: false
+    default: ''
+  slack_token:
+    description: "Slack bot token for failure notifications"
+    required: false
+    default: ''
+  slack_channel:
+    description: "Slack channel ID for failure notifications"
+    required: false
+    default: ''
+  slack_mention:
+    description: "Optional Slack handle or group to notify on failure"
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -24,9 +40,9 @@ runs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
-        ruby-version: ${{ inputs.ruby-version }}
+        ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ inputs.working_directory }}
 
     - name: Publish gem with attestation
       uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0
@@ -34,7 +50,18 @@ runs:
         await-release: ${{ inputs.dry_run == 'true' && 'false' || 'true' }}
         setup-trusted-publisher: ${{ inputs.dry_run == 'true' && 'false' || 'true' }}
         attestations: ${{ inputs.dry_run == 'true' && 'false' || 'true' }}
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ inputs.working_directory }}
       env:
         GITHUB_TOKEN: ${{ github.token }}
         DRY_RUN: ${{ inputs.dry_run }}
+
+    - name: Handle failure
+      if: failure()
+      uses: ./actions/release/lang/ruby/on-failure
+      with:
+        release_tag: ${{ inputs.release_tag }}
+        step: publish
+        working_directory: ${{ inputs.working_directory }}
+        slack_token: ${{ inputs.slack_token }}
+        slack_channel: ${{ inputs.slack_channel }}
+        slack_mention: ${{ inputs.slack_mention }}

--- a/actions/release/lang/ruby/validate/action.yml
+++ b/actions/release/lang/ruby/validate/action.yml
@@ -1,0 +1,107 @@
+name: Validate Ruby Release
+description: >
+  Checks out the release SHA, sets up Ruby, reads the gem version, validates
+  the release (tag existence, branch, commit metadata), and runs lint + build
+  to confirm the gem is publishable before the approval gate.
+
+inputs:
+  sha:
+    description: "Commit SHA being released"
+    required: true
+  dry_run:
+    description: "Skip tag existence failure in dry runs"
+    required: false
+    default: 'false'
+  version:
+    description: >
+      Explicit version override. If provided, version_file and version_module
+      are ignored. Use when the version is computed externally (e.g. bt-fake
+      auto-bump from run number).
+    required: false
+    default: ''
+  version_file:
+    description: "Path to the Ruby version file (e.g. lib/gem_name/version.rb)"
+    required: false
+    default: ''
+  version_module:
+    description: "Ruby module holding the VERSION constant (e.g. GemName)"
+    required: false
+    default: ''
+  working_directory:
+    description: "Path to the gem root (where Gemfile and gemspec live)"
+    required: false
+    default: '.'
+  ruby_version:
+    description: "Ruby version to use"
+    required: false
+    default: '4.0'
+outputs:
+  release_tag:
+    description: "The release tag (e.g. v0.3.2)"
+    value: ${{ steps.validate.outputs.release_tag }}
+  prev_release:
+    description: "The previous release tag"
+    value: ${{ steps.validate.outputs.prev_release }}
+  branch:
+    description: "The branch containing the SHA"
+    value: ${{ steps.validate.outputs.branch }}
+  on_release_branch:
+    description: "Whether the SHA is on an expected release branch"
+    value: ${{ steps.validate.outputs.on_release_branch }}
+  commit_message:
+    description: "The commit message at the SHA"
+    value: ${{ steps.validate.outputs.commit_message }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.sha }}
+        fetch-depth: 0
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
+      with:
+        ruby-version: ${{ inputs.ruby_version }}
+        bundler-cache: true
+        working-directory: ${{ inputs.working_directory }}
+
+    - name: Read version
+      id: read-version
+      shell: bash
+      env:
+        VERSION_OVERRIDE: ${{ inputs.version }}
+        VERSION_FILE: ${{ inputs.version_file }}
+        VERSION_MODULE: ${{ inputs.version_module }}
+      run: |
+        if [ -n "$VERSION_OVERRIDE" ]; then
+          echo "version=$VERSION_OVERRIDE" >> $GITHUB_OUTPUT
+        else
+          VERSION=$(ruby -r "./$VERSION_FILE" -e "puts Object.const_get(ENV.fetch('VERSION_MODULE')).const_get(:VERSION)")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Validate release
+      id: validate
+      uses: ./actions/release/validate
+      with:
+        version: ${{ steps.read-version.outputs.version }}
+        sha: ${{ inputs.sha }}
+        dry_run: ${{ inputs.dry_run }}
+
+    - name: Lint and build
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      env:
+        # Simulate rubygems/release-gem's RUBYOPT injection, which pre-loads gems
+        # (including openssl for attestation) before bundle exec runs. Exposes
+        # default gem activation conflicts before the approval gate.
+        RUBYOPT: "-r openssl"
+      run: bundle exec rake lint build
+
+    - name: Dump Ruby environment on failure
+      if: failure()
+      uses: ./actions/lang/ruby/env-dump
+      with:
+        working_directory: ${{ inputs.working_directory }}

--- a/actions/release/notify-failure/action.yml
+++ b/actions/release/notify-failure/action.yml
@@ -1,0 +1,60 @@
+name: Notify Release Failure
+description: >
+  Posts a Slack notification when a release step fails.
+  Includes who initiated the release and a link to the failing run.
+
+inputs:
+  release_tag:
+    description: "The release tag being attempted (e.g. v0.3.2)"
+    required: true
+  step:
+    description: "The step that failed (e.g. 'validate', 'publish')"
+    required: true
+  slack_token:
+    description: "Slack bot token"
+    required: false
+    default: ''
+  slack_channel:
+    description: "Slack channel ID"
+    required: false
+    default: ''
+  slack_mention:
+    description: "Optional Slack handle or group to notify (e.g. @sdk-eng)"
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Build failure message
+      id: message
+      if: ${{ inputs.slack_token != '' && inputs.slack_channel != '' }}
+      shell: bash
+      env:
+        RELEASE_TAG: ${{ inputs.release_tag }}
+        STEP: ${{ inputs.step }}
+        SLACK_MENTION: ${{ inputs.slack_mention }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        ACTOR_LINK: <${{ github.server_url }}/${{ github.actor }}|${{ github.actor }}>
+      run: |
+        TEXT=":x: *$GITHUB_REPOSITORY $RELEASE_TAG* failed at $STEP"
+        TEXT="$TEXT\nInitiated by: $ACTOR_LINK"
+
+        if [ -n "$SLACK_MENTION" ]; then
+          TEXT="$TEXT  $SLACK_MENTION"
+        fi
+
+        TEXT="$TEXT\n<$RUN_URL|View failed run>"
+
+        { echo 'text<<SLACK_DELIMITER'
+          printf '%s\n' "$TEXT"
+          echo 'SLACK_DELIMITER'
+        } >> $GITHUB_OUTPUT
+
+    - name: Send Slack message
+      if: ${{ inputs.slack_token != '' && inputs.slack_channel != '' }}
+      uses: ./actions/slack/send
+      with:
+        token: ${{ inputs.slack_token }}
+        channel: ${{ inputs.slack_channel }}
+        text: ${{ steps.message.outputs.text }}

--- a/actions/release/notify-pending/action.yml
+++ b/actions/release/notify-pending/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: "Branch containing the SHA"
     required: true
   on_release_branch:
-    description: "Whether the SHA is on the main branch"
+    description: "Whether the SHA is on an expected release branch"
     required: true
   commit_message:
     description: "Commit message at the SHA"
@@ -43,6 +43,10 @@ inputs:
     description: "Slack channel ID to post to"
     required: false
     default: ''
+  slack_mention:
+    description: "Optional Slack handle or group to @mention in the approval request (e.g. @sdk-eng)"
+    required: false
+    default: ''
   emoji:
     description: "Emoji prefix for Slack messages"
     required: false
@@ -56,75 +60,87 @@ runs:
       env:
         TAG: ${{ inputs.release_tag }}
         COMMIT_MSG: ${{ inputs.commit_message }}
+        NOTES_B64: ${{ inputs.notes }}
+        BRANCH: ${{ inputs.branch }}
+        SHA: ${{ inputs.sha }}
+        PREV_RELEASE: ${{ inputs.prev_release }}
+        ON_RELEASE_BRANCH: ${{ inputs.on_release_branch }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        ACTOR: ${{ github.actor }}
       run: |
-        NOTES=$(echo "${{ inputs.notes }}" | base64 -d 2>/dev/null)
+        NOTES=$(echo "$NOTES_B64" | base64 -d 2>/dev/null)
         if [ -z "$NOTES" ]; then NOTES="_Release notes unavailable._"; fi
 
-        BRANCH_LABEL="[${{ inputs.branch }}]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/${{ inputs.branch }})"
-        if [ "${{ inputs.on_release_branch }}" = "false" ]; then
+        BRANCH_LABEL="[$BRANCH]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/$BRANCH)"
+        if [ "$ON_RELEASE_BRANCH" = "false" ]; then
           BRANCH_LABEL="$BRANCH_LABEL ⚠️"
         fi
 
         echo "## $GITHUB_REPOSITORY $TAG" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
-        if [ "${{ inputs.dry_run }}" = "true" ]; then
+        if [ "$DRY_RUN" = "true" ]; then
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> Dry run: Nothing will be tagged or published." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
         fi
 
-        if [ "${{ inputs.on_release_branch }}" = "false" ]; then
+        if [ "$ON_RELEASE_BRANCH" = "false" ]; then
           echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
-          echo "> Release SHA is not on a release branch (expected: ${{ inputs.release_branch }}). Is this intentional?" >> $GITHUB_STEP_SUMMARY
+          echo "> Release SHA is not on an expected release branch. Is this intentional?" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
         fi
 
-        echo "**SHA:** [${{ inputs.sha }}]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/${{ inputs.sha }})" >> $GITHUB_STEP_SUMMARY
+        echo "**SHA:** [$SHA]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$SHA)" >> $GITHUB_STEP_SUMMARY
         echo "**Commit:** $COMMIT_MSG" >> $GITHUB_STEP_SUMMARY
         echo "**Branch:** $BRANCH_LABEL" >> $GITHUB_STEP_SUMMARY
+        echo "**Initiated by:** [$ACTOR]($GITHUB_SERVER_URL/$ACTOR)" >> $GITHUB_STEP_SUMMARY
 
-        if [ -n "${{ inputs.prev_release }}" ]; then
-          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${{ inputs.prev_release }}...${{ inputs.sha }}"
-          echo "**Diff:** [${{ inputs.prev_release }}...$TAG]($DIFF_URL)" >> $GITHUB_STEP_SUMMARY
+        if [ -n "$PREV_RELEASE" ]; then
+          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${PREV_RELEASE}...${SHA}"
+          echo "**Diff:** [${PREV_RELEASE}...$TAG]($DIFF_URL)" >> $GITHUB_STEP_SUMMARY
         fi
 
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "$NOTES" >> $GITHUB_STEP_SUMMARY
 
-    - name: Notify Slack
+    - name: Build Slack message
+      id: message
+      if: ${{ inputs.slack_token != '' && inputs.slack_channel != '' }}
       shell: bash
       env:
-        SLACK_BOT_TOKEN: ${{ inputs.slack_token }}
-        SLACK_CHANNEL: ${{ inputs.slack_channel }}
         TAG: ${{ inputs.release_tag }}
+        EMOJI: ${{ inputs.emoji }}
+        BRANCH: ${{ inputs.branch }}
+        ON_RELEASE_BRANCH: ${{ inputs.on_release_branch }}
+        PREV_RELEASE: ${{ inputs.prev_release }}
+        SHA: ${{ inputs.sha }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        SLACK_MENTION: ${{ inputs.slack_mention }}
         APPROVE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        ACTOR_LINK: <${{ github.server_url }}/${{ github.actor }}|${{ github.actor }}>
         PR_LIST_RAW: ${{ inputs.pr_list }}
       run: |
-        if [ -z "$SLACK_BOT_TOKEN" ] || [ -z "$SLACK_CHANNEL" ]; then
-          echo "Slack not configured (slack_token or slack_channel not provided) — skipping notification."
-          exit 0
-        fi
-
-        BRANCH_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/${{ inputs.branch }}"
-        BRANCH_LINK="<$BRANCH_URL|${{ inputs.branch }}>"
-        if [ "${{ inputs.on_release_branch }}" = "false" ]; then
+        BRANCH_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/$BRANCH"
+        BRANCH_LINK="<$BRANCH_URL|$BRANCH>"
+        if [ "$ON_RELEASE_BRANCH" = "false" ]; then
           BRANCH_INFO="> ⚠️ NOT on release branch: $BRANCH_LINK"
         else
           BRANCH_INFO="$BRANCH_LINK"
         fi
 
         DIFF_PART=""
-        if [ -n "${{ inputs.prev_release }}" ]; then
-          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${{ inputs.prev_release }}...${{ inputs.sha }}"
-          DIFF_PART=" · <$DIFF_URL|${{ inputs.prev_release }}...$TAG>"
+        if [ -n "$PREV_RELEASE" ]; then
+          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${PREV_RELEASE}...${SHA}"
+          DIFF_PART=" · <$DIFF_URL|${PREV_RELEASE}...$TAG>"
         fi
 
         PR_LIST=$(echo "$PR_LIST_RAW" | tr $'\x1f' '\n' | sed '/^$/d')
 
-        TEXT="${{ inputs.emoji }} *$GITHUB_REPOSITORY $TAG* awaiting approval"
+        TEXT="$EMOJI *$GITHUB_REPOSITORY $TAG* awaiting approval"
+        TEXT="$TEXT\nInitiated by: $ACTOR_LINK"
 
-        if [ "${{ inputs.dry_run }}" = "true" ]; then
+        if [ "$DRY_RUN" = "true" ]; then
           TEXT="$TEXT\n> :information_source: _Dry run: nothing will be tagged or published._"
         fi
 
@@ -134,12 +150,21 @@ runs:
           TEXT="$TEXT\n$PR_LIST"
         fi
 
+        if [ -n "$SLACK_MENTION" ]; then
+          TEXT="$TEXT\n$SLACK_MENTION please review and approve."
+        fi
+
         TEXT="$TEXT\n<$APPROVE_URL|View changes & approve>"
 
-        # jq --arg passes strings literally, so \n must be real newlines before encoding
-        TEXT=$(printf '%b' "$TEXT")
-        curl -s -X POST "https://slack.com/api/chat.postMessage" \
-          -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-          -H "Content-Type: application/json; charset=utf-8" \
-          -d "$(jq -n --arg channel "$SLACK_CHANNEL" --arg text "$TEXT" \
-            '{channel: $channel, text: $text}')"
+        { echo 'text<<SLACK_DELIMITER'
+          printf '%s\n' "$TEXT"
+          echo 'SLACK_DELIMITER'
+        } >> $GITHUB_OUTPUT
+
+    - name: Send Slack message
+      if: ${{ inputs.slack_token != '' && inputs.slack_channel != '' }}
+      uses: ./actions/slack/send
+      with:
+        token: ${{ inputs.slack_token }}
+        channel: ${{ inputs.slack_channel }}
+        text: ${{ steps.message.outputs.text }}

--- a/actions/release/notify-published/action.yml
+++ b/actions/release/notify-published/action.yml
@@ -1,6 +1,6 @@
 name: Notify Release Complete
 description: >
-  Posts the post-publish Slack notification with release link and PR list.
+  Posts a step summary and Slack notification when a release completes.
 
 inputs:
   release_tag:
@@ -14,7 +14,7 @@ inputs:
     description: "Branch the release was made from"
     required: true
   on_release_branch:
-    description: "Whether the release was from main"
+    description: "Whether the release was from an expected release branch"
     required: true
   pr_list:
     description: "x1f-delimited PR list from prepare action"
@@ -36,60 +36,131 @@ inputs:
     description: "Emoji prefix for Slack messages"
     required: false
     default: ':package:'
+  links:
+    description: >
+      JSON array of links to include in the summary and Slack message.
+      Each entry: {"label": "...", "url": "..."}. The GitHub Release link
+      is always prepended automatically (unless dry run).
+      Example: [{"label":"RubyGems","url":"https://rubygems.org/..."}]
+    required: false
+    default: '[]'
 
 runs:
   using: composite
   steps:
-    - name: Notify Slack
+    - name: Post release summary
       shell: bash
       env:
-        SLACK_BOT_TOKEN: ${{ inputs.slack_token }}
-        SLACK_CHANNEL: ${{ inputs.slack_channel }}
         TAG: ${{ inputs.release_tag }}
+        PREV_RELEASE: ${{ inputs.prev_release }}
+        BRANCH: ${{ inputs.branch }}
+        ON_RELEASE_BRANCH: ${{ inputs.on_release_branch }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        LINKS_JSON: ${{ inputs.links }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        RELEASE_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/$TAG"
+        BRANCH_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/$BRANCH"
+
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "## $GITHUB_REPOSITORY $TAG — dry run complete" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "## $GITHUB_REPOSITORY $TAG — published ✅" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
+          echo "> Dry run: Nothing was tagged or published." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        if [ "$ON_RELEASE_BRANCH" = "false" ]; then
+          echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
+          echo "> Released from non-release branch: [$BRANCH]($BRANCH_URL)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        echo "**Branch:** [$BRANCH]($BRANCH_URL)" >> $GITHUB_STEP_SUMMARY
+
+        if [ -n "$PREV_RELEASE" ]; then
+          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${PREV_RELEASE}...$TAG"
+          echo "**Diff:** [$PREV_RELEASE...$TAG]($DIFF_URL)" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Published to" >> $GITHUB_STEP_SUMMARY
+
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "- [View dry run]($RUN_URL)" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- [GitHub Release]($RELEASE_URL)" >> $GITHUB_STEP_SUMMARY
+          if [ -n "$LINKS_JSON" ] && [ "$LINKS_JSON" != "[]" ]; then
+            echo "$LINKS_JSON" | jq -r '.[] | "- [\(.label)](\(.url))"' >> $GITHUB_STEP_SUMMARY
+          fi
+        fi
+
+    - name: Build Slack message
+      id: message
+      if: ${{ inputs.slack_token != '' && inputs.slack_channel != '' }}
+      shell: bash
+      env:
+        TAG: ${{ inputs.release_tag }}
+        EMOJI: ${{ inputs.emoji }}
+        BRANCH: ${{ inputs.branch }}
+        ON_RELEASE_BRANCH: ${{ inputs.on_release_branch }}
+        PREV_RELEASE: ${{ inputs.prev_release }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        LINKS_JSON: ${{ inputs.links }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         PR_LIST_RAW: ${{ inputs.pr_list }}
       run: |
-        if [ -z "$SLACK_BOT_TOKEN" ] || [ -z "$SLACK_CHANNEL" ]; then
-          echo "Slack not configured (slack_token or slack_channel not provided) — skipping notification."
-          exit 0
-        fi
-
         RELEASE_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/$TAG"
 
         DIFF_PART=""
-        if [ -n "${{ inputs.prev_release }}" ]; then
-          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${{ inputs.prev_release }}...$TAG"
-          DIFF_PART="<$DIFF_URL|${{ inputs.prev_release }}...$TAG>  ·  "
+        if [ -n "$PREV_RELEASE" ]; then
+          DIFF_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${PREV_RELEASE}...$TAG"
+          DIFF_PART="<$DIFF_URL|${PREV_RELEASE}...$TAG>  ·  "
         fi
 
         PR_LIST=$(echo "$PR_LIST_RAW" | tr $'\x1f' '\n' | sed '/^$/d')
 
-        if [ "${{ inputs.dry_run }}" = "true" ]; then
-          TEXT="${{ inputs.emoji }} *$GITHUB_REPOSITORY $TAG* complete"
-          TEXT="$TEXT\n> :information_source: _Dry run: gem built, nothing tagged or published._"
+        if [ "$DRY_RUN" = "true" ]; then
+          TEXT="$EMOJI *$GITHUB_REPOSITORY $TAG* complete"
+          TEXT="$TEXT\n> :information_source: _Dry run: nothing tagged or published._"
         else
-          TEXT="${{ inputs.emoji }} *$GITHUB_REPOSITORY $TAG* published"
+          TEXT="$EMOJI *$GITHUB_REPOSITORY $TAG* published"
         fi
 
-        if [ "${{ inputs.on_release_branch }}" = "false" ]; then
-          BRANCH_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/${{ inputs.branch }}"
-          TEXT="$TEXT\n> ⚠️ NOT on release branch: <$BRANCH_URL|${{ inputs.branch }}>"
+        if [ "$ON_RELEASE_BRANCH" = "false" ]; then
+          BRANCH_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/$BRANCH"
+          TEXT="$TEXT\n> ⚠️ NOT on release branch: <$BRANCH_URL|$BRANCH>"
         fi
 
-        if [ "${{ inputs.dry_run }}" = "true" ]; then
+        if [ "$DRY_RUN" = "true" ]; then
           TEXT="$TEXT\n${DIFF_PART}<$RUN_URL|View dry run>"
         else
-          TEXT="$TEXT\n${DIFF_PART}<$RELEASE_URL|View release>"
+          SLACK_LINKS="${DIFF_PART}<$RELEASE_URL|View release>"
+          if [ -n "$LINKS_JSON" ] && [ "$LINKS_JSON" != "[]" ]; then
+            EXTRA=$(echo "$LINKS_JSON" | jq -r '[.[] | "<\(.url)|\(.label)>"] | join("  ·  ")')
+            SLACK_LINKS="$SLACK_LINKS  ·  $EXTRA"
+          fi
+          TEXT="$TEXT\n$SLACK_LINKS"
         fi
 
         if [ -n "$PR_LIST" ]; then
           TEXT="$TEXT\n$PR_LIST"
         fi
 
-        # jq --arg passes strings literally, so \n must be real newlines before encoding
-        TEXT=$(printf '%b' "$TEXT")
-        curl -s -X POST "https://slack.com/api/chat.postMessage" \
-          -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-          -H "Content-Type: application/json; charset=utf-8" \
-          -d "$(jq -n --arg channel "$SLACK_CHANNEL" --arg text "$TEXT" \
-            '{channel: $channel, text: $text}')"
+        { echo 'text<<SLACK_DELIMITER'
+          printf '%s\n' "$TEXT"
+          echo 'SLACK_DELIMITER'
+        } >> $GITHUB_OUTPUT
+
+    - name: Send Slack message
+      if: ${{ inputs.slack_token != '' && inputs.slack_channel != '' }}
+      uses: ./actions/slack/send
+      with:
+        token: ${{ inputs.slack_token }}
+        channel: ${{ inputs.slack_channel }}
+        text: ${{ steps.message.outputs.text }}

--- a/actions/release/validate/action.yml
+++ b/actions/release/validate/action.yml
@@ -51,8 +51,10 @@ runs:
   steps:
     - name: Validate SHA format
       shell: bash
+      env:
+        SHA: ${{ inputs.sha }}
       run: |
-        if ! echo "${{ inputs.sha }}" | grep -qE '^[0-9a-f]{40}$'; then
+        if ! echo "$SHA" | grep -qE '^[0-9a-f]{40}$'; then
           echo "Error: sha must be a full 40-character commit SHA — branch names and short SHAs are not accepted."
           exit 1
         fi
@@ -60,15 +62,19 @@ runs:
     - name: Validate release
       id: validate
       shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        TAG_FORMAT: ${{ inputs.tag_format }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        RELEASE_BRANCH: ${{ inputs.release_branch }}
+        SHA: ${{ inputs.sha }}
       run: |
-        VERSION="${{ inputs.version }}"
-        TAG="${{ inputs.tag_format }}"
-        TAG="${TAG//\{version\}/$VERSION}"
+        TAG="${TAG_FORMAT//\{version\}/$VERSION}"
         COMMIT_MSG=$(git log -1 --format="%s" HEAD)
         BRANCH=$(git branch -r --contains HEAD --format="%(refname:short)" | sed 's|origin/||' | head -1)
 
         if git rev-parse "$TAG" >/dev/null 2>&1; then
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             echo "Warning: Tag $TAG already exists — skipping in dry run"
           else
             echo "Error: Tag $TAG already exists — has the version been bumped?"
@@ -77,7 +83,7 @@ runs:
         fi
 
         ON_RELEASE_BRANCH=false
-        IFS=',' read -ra PATTERNS <<< "${{ inputs.release_branch }}"
+        IFS=',' read -ra PATTERNS <<< "$RELEASE_BRANCH"
         for pattern in "${PATTERNS[@]}"; do
           pattern=$(echo "$pattern" | xargs)
           if [[ "$BRANCH" == $pattern ]]; then
@@ -86,8 +92,7 @@ runs:
           fi
         done
 
-        PREV_RELEASE_PATTERN="${{ inputs.tag_format }}"
-        PREV_RELEASE_PATTERN="${PREV_RELEASE_PATTERN//\{version\}/[0-9]*.[0-9]*.[0-9]*}"
+        PREV_RELEASE_PATTERN="${TAG_FORMAT//\{version\}/[0-9]*.[0-9]*.[0-9]*}"
         PREV_RELEASE=$(git describe --tags --abbrev=0 --match="$PREV_RELEASE_PATTERN" HEAD^ 2>/dev/null || echo "")
 
         echo "release_tag=$TAG" >> $GITHUB_OUTPUT
@@ -95,4 +100,4 @@ runs:
         echo "branch=$BRANCH" >> $GITHUB_OUTPUT
         echo "on_release_branch=$ON_RELEASE_BRANCH" >> $GITHUB_OUTPUT
         echo "prev_release=$PREV_RELEASE" >> $GITHUB_OUTPUT
-        echo "Validated $TAG @ ${{ inputs.sha }} ($COMMIT_MSG)"
+        echo "Validated $TAG @ $SHA ($COMMIT_MSG)"

--- a/actions/slack/send/action.yml
+++ b/actions/slack/send/action.yml
@@ -1,0 +1,46 @@
+name: Send Slack Message
+description: >
+  Sends a message to a Slack channel via the chat.postMessage API.
+  Separated from formatting concerns — callers build the text, this just sends.
+
+inputs:
+  token:
+    description: "Slack bot token"
+    required: true
+  channel:
+    description: "Slack channel ID"
+    required: true
+  text:
+    description: "Message text (supports Slack mrkdwn, \\n for newlines)"
+    required: true
+  fail_on_error:
+    description: "Fail the step if the Slack API call fails. Set to true when the notification is critical."
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Send message
+      shell: bash
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.token }}
+        SLACK_CHANNEL: ${{ inputs.channel }}
+        TEXT: ${{ inputs.text }}
+        FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
+      run: |
+        # jq --arg passes strings literally, so \n must be real newlines before encoding
+        TEXT=$(printf '%b' "$TEXT")
+        RESPONSE=$(curl -s --max-time 10 -X POST "https://slack.com/api/chat.postMessage" \
+          -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+          -H "Content-Type: application/json; charset=utf-8" \
+          -d "$(jq -n --arg channel "$SLACK_CHANNEL" --arg text "$TEXT" \
+            '{channel: $channel, text: $text}')") || true
+        if echo "$RESPONSE" | jq -e '.ok' > /dev/null 2>&1; then
+          echo "Slack notification sent."
+        elif [ "$FAIL_ON_ERROR" = "true" ]; then
+          echo "Slack notification failed: $RESPONSE"
+          exit 1
+        else
+          echo "::warning::Slack notification failed: $RESPONSE"
+        fi

--- a/test/release/ruby/Gemfile
+++ b/test/release/ruby/Gemfile
@@ -4,5 +4,17 @@ source "https://rubygems.org"
 
 gemspec
 
+# Added to test when a gem added to the gemspec conflicts with one that is also
+# a part of Ruby by default, resulting in activation errors.
+#
+# How to fix:
+#
+# Pin openssl to Ruby 4.0's bundled default (4.0.0) to avoid bundler activation
+# conflicts with RUBYOPT pre-loading. Update when ruby_version bumps.
+#
+# This becomes obsolete when this dependency is removed from the gemspec.
+#
+gem "openssl", "4.0.0"
+
 gem "rake", "~> 13.0"
 gem "standard", "~> 1.0"

--- a/test/release/ruby/Gemfile.lock
+++ b/test/release/ruby/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     bt-fake (0.0.1)
+      openssl (>= 3.3.1, < 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -10,6 +11,7 @@ GEM
     json (2.19.7)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    openssl (4.0.0)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -59,8 +61,9 @@ PLATFORMS
 
 DEPENDENCIES
   bt-fake!
+  openssl (= 4.0.0)
   rake (~> 13.0)
   standard (~> 1.0)
 
 BUNDLED WITH
-   2.4.19
+   4.0.8

--- a/test/release/ruby/bt-fake.gemspec
+++ b/test/release/ruby/bt-fake.gemspec
@@ -13,4 +13,9 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob("lib/**/*.rb")
   spec.require_paths = ["lib"]
+
+  # Mirrors real SDK gemspecs that depend on openssl. Keeps the lockfile pinned
+  # to the runner's default gem version so the RUBYOPT activation test in
+  # validate-ruby remains meaningful as Ruby versions change.
+  spec.add_runtime_dependency "openssl", ">= 3.3.1", "< 5.0"
 end


### PR DESCRIPTION
Refactors the Ruby release pipeline into smaller, recomposable actions under a `lang/ruby/` namespace, and adds several improvements that were missing from the initial prototype.

### New capabilities

- **Release step summary on publish**: the publish job now writes a GitHub Actions step summary confirming what shipped, with links to the GitHub Release and registry (e.g. RubyGems). Dry runs are distinguished from real releases.
- **Failure notifications**: publish failures now send a Slack notification with the failing step, who initiated the release, and a link to the run. Validate failures intentionally do not notify (reviewers shouldn't hear "failed" before they knew a release was happening).
- **Actor attribution**: the pending approval message now shows who triggered the release as a clickable link.
- **Extensible publish links**: `notify-published` accepts a `links` JSON array (`[{"label":…,"url":…}]`) so language-specific wrappers can pass any combination of registry, docs, or other references. The Ruby wrapper populates RubyGems automatically.
- **Slack soft-fail**: Slack notification errors emit a warning annotation instead of failing the release job. A `fail_on_error` input opts in to hard failure when the notification is critical.
- **Pre-publish activation conflict detection**: validate runs `bundle exec rake lint build` under `RUBYOPT="-r openssl"` to surface default gem version conflicts before the approval gate, matching what `rubygems/release-gem` does at publish time.

### Structure

- `actions/lang/ruby/env-dump`: dumps Ruby version, bundler, and default gems; called on validate failure for diagnostics
- `actions/release/lang/ruby/{validate,publish,on-failure,notify-published}`: composable Ruby-specific steps
- `actions/release/notify-failure`: generic failure Slack notification (actor link, run link, optional mention)
- `actions/slack/send`: centralized Slack `chat.postMessage` call extracted from notification actions

### Security

- All user-controlled `${{ inputs.* }}` in `run:` blocks moved to `env:` variables across `validate`, `notify-pending`, and `notify-failure`
- `VERSION_MODULE` in Ruby version read uses `Object.const_get(ENV.fetch(...))` instead of shell interpolation into `ruby -e`
