### PR TITLE
Consolidate publish actions under one ruby/publish action

### DIFF
--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -72,11 +72,15 @@ jobs:
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
-      # bt-fake: generates a version from the run number — no version bump PR needed.
-      # Remove this job in real SDK workflows; version comes from the version bump PR.
+      # bt-fake: derives next version by querying RubyGems.org and incrementing the
+      # patch. Falls back to 0.0.1 on first publish (404). Remove this job in real
+      # SDK workflows; version comes from the version bump PR.
       - name: Bump version
         id: bump
-        run: echo "version=0.0.${{ github.run_number }}" >> $GITHUB_OUTPUT
+        run: |
+          CURRENT=$(curl -sf https://rubygems.org/api/v1/gems/bt-fake.json | jq -r '.version' || echo "0.0.0")
+          IFS='.' read -r major minor patch <<< "$CURRENT"
+          echo "version=$major.$minor.$((patch + 1))" >> $GITHUB_OUTPUT
 
   validate:
     needs: bump

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -184,37 +184,22 @@ jobs:
           sed -i "s|bt-fake ([0-9]*\.[0-9]*\.[0-9]*)|bt-fake ($VERSION)|" \
             test/release/ruby/Gemfile.lock
 
-      # Update working-directory to your gem's root
-      - name: Publish gem
+      - name: Publish
         uses: ./actions/release/lang/ruby/publish
         with:
+          sha: ${{ inputs.sha }}
+          checkout: 'false' # bt-fake: skip internal checkout — version patching above must survive into the gem build
           working_directory: test/release/ruby
           dry_run: ${{ inputs.dry_run }}
           release_tag: ${{ needs.validate.outputs.release_tag }}
-          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          slack_channel: ${{ vars.SLACK_SDK_RELEASE_CHANNEL }}
-          # slack_mention: '@sdk-eng'
-
-      # bt-fake: GitHub release creation disabled to avoid tag/release pollution
-      # from repeated test runs. In real SDK workflows, uncomment this step.
-      # - name: Create GitHub release
-      #   uses: ./actions/release/create-github-release
-      #   with:
-      #     release_tag: ${{ needs.validate.outputs.release_tag }}
-      #     sha: ${{ inputs.sha }}
-      #     notes: ${{ needs.prepare.outputs.notes }}
-      #     dry_run: ${{ inputs.dry_run }}
-
-      - name: Notify release complete
-        uses: ./actions/release/lang/ruby/notify-published
-        with:
-          release_tag: ${{ needs.validate.outputs.release_tag }}
+          github_release: 'false' # bt-fake: omit GitHub release to avoid tag/release pollution from repeated test runs
+          notes: ${{ needs.prepare.outputs.notes }}
           prev_release: ${{ needs.validate.outputs.prev_release }}
           branch: ${{ needs.validate.outputs.branch }}
           on_release_branch: ${{ needs.validate.outputs.on_release_branch }}
           pr_list: ${{ needs.prepare.outputs.pr_list }}
-          dry_run: ${{ inputs.dry_run }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack_channel: ${{ vars.SLACK_SDK_RELEASE_CHANNEL }}
           # slack_mention: '@sdk-eng'
+          # failure_slack_mention: '@sdk-eng'
           gem_name: bt-fake

--- a/actions/release/lang/ruby/notify-published/action.yml
+++ b/actions/release/lang/ruby/notify-published/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "Slack channel ID"
     required: false
     default: ''
+  slack_mention:
+    description: "Optional Slack handle or group to @mention on completion (e.g. @sdk-eng)"
+    required: false
+    default: ''
   emoji:
     description: "Emoji prefix for Slack messages"
     required: false
@@ -70,5 +74,6 @@ runs:
         dry_run: ${{ inputs.dry_run }}
         slack_token: ${{ inputs.slack_token }}
         slack_channel: ${{ inputs.slack_channel }}
+        slack_mention: ${{ inputs.slack_mention }}
         emoji: ${{ inputs.emoji }}
         links: ${{ steps.links.outputs.links }}

--- a/actions/release/lang/ruby/publish/action.yml
+++ b/actions/release/lang/ruby/publish/action.yml
@@ -1,12 +1,19 @@
-name: Publish Ruby Gem
+name: Publish Ruby SDK Release
 description: >
-  Sets up Ruby and publishes a gem to RubyGems with OIDC trusted publishing
-  and SLSA attestation via rubygems/release-gem. Reads DRY_RUN from the
-  environment — set DRY_RUN=true to lint and build without pushing.
+  Full Ruby gem release: checks out the SHA, pushes to RubyGems, creates
+  a GitHub release, and sends a Slack completion notification. Covers the
+  standard publish sequence for all Braintrust Ruby SDKs.
 
 inputs:
+  sha:
+    description: "Commit SHA to check out and release"
+    required: true
+  checkout:
+    description: "Check out the SHA before publishing. Set to false when the caller has already checked out and patched files."
+    required: false
+    default: 'true'
   working_directory:
-    description: "Path to the gem root (where the Gemfile and gemspec live)"
+    description: "Path to the gem root (where Gemfile and gemspec live)"
     required: false
     default: '.'
   ruby_version:
@@ -14,54 +21,99 @@ inputs:
     required: false
     default: '4.0'
   dry_run:
-    description: "Skip gem push and tag push"
+    description: "Skip gem push, tag push, and GitHub release creation"
     required: false
     default: 'false'
   release_tag:
-    description: "The release tag — used in failure notifications"
+    description: "The release tag (e.g. v0.3.2)"
+    required: true
+  github_release:
+    description: "Whether to create a GitHub release"
+    required: false
+    default: 'true'
+  notes:
+    description: "Base64-encoded release notes from the prepare action"
+    required: false
+    default: ''
+  prev_release:
+    description: "Previous release tag — used in completion notification"
+    required: false
+    default: ''
+  branch:
+    description: "Branch the release was made from"
+    required: true
+  on_release_branch:
+    description: "Whether the SHA is on an expected release branch"
+    required: true
+  pr_list:
+    description: "x1f-delimited PR list from prepare action"
+    required: false
+    default: ''
+  gem_name:
+    description: "RubyGems gem name — used to build the RubyGems link in notifications"
     required: false
     default: ''
   slack_token:
-    description: "Slack bot token for failure notifications"
+    description: "Slack bot token"
     required: false
     default: ''
   slack_channel:
-    description: "Slack channel ID for failure notifications"
+    description: "Slack channel ID"
     required: false
     default: ''
   slack_mention:
-    description: "Optional Slack handle or group to notify on failure"
+    description: "Optional Slack handle or group to @mention on completion"
     required: false
     default: ''
+  failure_slack_mention:
+    description: "Optional Slack handle or group to @mention if the gem push fails"
+    required: false
+    default: ''
+  emoji:
+    description: "Emoji prefix for Slack messages"
+    required: false
+    default: ':ruby:'
 
 runs:
   using: composite
   steps:
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      if: ${{ inputs.checkout == 'true' }}
       with:
-        ruby-version: ${{ inputs.ruby_version }}
-        bundler-cache: true
-        working-directory: ${{ inputs.working_directory }}
+        ref: ${{ inputs.sha }}
+        fetch-depth: 0
 
-    - name: Publish gem with attestation
-      uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0
+    - name: Push to RubyGems
+      uses: ./actions/release/lang/ruby/rubygems-push
       with:
-        await-release: ${{ inputs.dry_run == 'true' && 'false' || 'true' }}
-        setup-trusted-publisher: ${{ inputs.dry_run == 'true' && 'false' || 'true' }}
-        attestations: ${{ inputs.dry_run == 'true' && 'false' || 'true' }}
-        working-directory: ${{ inputs.working_directory }}
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-        DRY_RUN: ${{ inputs.dry_run }}
+        working_directory: ${{ inputs.working_directory }}
+        ruby_version: ${{ inputs.ruby_version }}
+        dry_run: ${{ inputs.dry_run }}
+        release_tag: ${{ inputs.release_tag }}
+        slack_token: ${{ inputs.slack_token }}
+        slack_channel: ${{ inputs.slack_channel }}
+        failure_slack_mention: ${{ inputs.failure_slack_mention }}
 
-    - name: Handle failure
-      if: failure()
-      uses: ./actions/release/lang/ruby/on-failure
+    - name: Create GitHub release
+      if: ${{ inputs.github_release == 'true' }}
+      uses: ./actions/release/create-github-release
       with:
         release_tag: ${{ inputs.release_tag }}
-        step: publish
-        working_directory: ${{ inputs.working_directory }}
+        sha: ${{ inputs.sha }}
+        notes: ${{ inputs.notes }}
+        dry_run: ${{ inputs.dry_run }}
+
+    - name: Notify release complete
+      uses: ./actions/release/lang/ruby/notify-published
+      with:
+        release_tag: ${{ inputs.release_tag }}
+        prev_release: ${{ inputs.prev_release }}
+        branch: ${{ inputs.branch }}
+        on_release_branch: ${{ inputs.on_release_branch }}
+        pr_list: ${{ inputs.pr_list }}
+        dry_run: ${{ inputs.dry_run }}
         slack_token: ${{ inputs.slack_token }}
         slack_channel: ${{ inputs.slack_channel }}
         slack_mention: ${{ inputs.slack_mention }}
+        gem_name: ${{ inputs.gem_name }}
+        emoji: ${{ inputs.emoji }}

--- a/actions/release/lang/ruby/rubygems-push/action.yml
+++ b/actions/release/lang/ruby/rubygems-push/action.yml
@@ -1,0 +1,67 @@
+name: Push Ruby Gem to RubyGems
+description: >
+  Sets up Ruby and pushes a gem to RubyGems with OIDC trusted publishing
+  and SLSA attestation via rubygems/release-gem. Reads DRY_RUN from the
+  environment — set DRY_RUN=true to build without pushing.
+
+inputs:
+  working_directory:
+    description: "Path to the gem root (where the Gemfile and gemspec live)"
+    required: false
+    default: '.'
+  ruby_version:
+    description: "Ruby version to use"
+    required: false
+    default: '4.0'
+  dry_run:
+    description: "Skip gem push and tag push"
+    required: false
+    default: 'false'
+  release_tag:
+    description: "The release tag — used in failure notifications"
+    required: false
+    default: ''
+  slack_token:
+    description: "Slack bot token for failure notifications"
+    required: false
+    default: ''
+  slack_channel:
+    description: "Slack channel ID for failure notifications"
+    required: false
+    default: ''
+  failure_slack_mention:
+    description: "Optional Slack handle or group to @mention if publishing fails"
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
+      with:
+        ruby-version: ${{ inputs.ruby_version }}
+        bundler-cache: true
+        working-directory: ${{ inputs.working_directory }}
+
+    - name: Publish gem with attestation
+      uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0
+      with:
+        await-release: ${{ inputs.dry_run == 'true' && 'false' || 'true' }}
+        setup-trusted-publisher: ${{ inputs.dry_run == 'true' && 'false' || 'true' }}
+        attestations: ${{ inputs.dry_run == 'true' && 'false' || 'true' }}
+        working-directory: ${{ inputs.working_directory }}
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        DRY_RUN: ${{ inputs.dry_run }}
+
+    - name: Handle failure
+      if: failure()
+      uses: ./actions/release/lang/ruby/on-failure
+      with:
+        release_tag: ${{ inputs.release_tag }}
+        step: publish
+        working_directory: ${{ inputs.working_directory }}
+        slack_token: ${{ inputs.slack_token }}
+        slack_channel: ${{ inputs.slack_channel }}
+        slack_mention: ${{ inputs.failure_slack_mention }}

--- a/actions/release/notify-published/action.yml
+++ b/actions/release/notify-published/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: "Slack channel ID to post to"
     required: false
     default: ''
+  slack_mention:
+    description: "Optional Slack handle or group to @mention on completion (e.g. @sdk-eng)"
+    required: false
+    default: ''
   emoji:
     description: "Emoji prefix for Slack messages"
     required: false
@@ -111,6 +115,7 @@ runs:
         ON_RELEASE_BRANCH: ${{ inputs.on_release_branch }}
         PREV_RELEASE: ${{ inputs.prev_release }}
         DRY_RUN: ${{ inputs.dry_run }}
+        SLACK_MENTION: ${{ inputs.slack_mention }}
         LINKS_JSON: ${{ inputs.links }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         PR_LIST_RAW: ${{ inputs.pr_list }}
@@ -150,6 +155,10 @@ runs:
 
         if [ -n "$PR_LIST" ]; then
           TEXT="$TEXT\n$PR_LIST"
+        fi
+
+        if [ -n "$SLACK_MENTION" ]; then
+          TEXT="$TEXT\n$SLACK_MENTION"
         fi
 
         { echo 'text<<SLACK_DELIMITER'


### PR DESCRIPTION
- **Consolidate Ruby publish steps** into a single `lang/ruby/publish` action (checkout → RubyGems push → GitHub release → Slack notification).
- **Rename the existing `lang/ruby/publish` → `lang/ruby/rubygems-push`** to reflect its narrower scope and leave room for additional registries.
- **Rename `slack_mention` → `failure_slack_mention`** on `lang/ruby/publish` (now `rubygems-push`) to clarify it only fires on failure, not on every message.
- **Add `slack_mention` to `notify-published`** so callers can optionally @mention a group on release completion.
- **bt-fake version bump**: query RubyGems.org for the latest published version and increment the patch, replacing the run-number-based scheme.
