### PR TITLE
Bumped release action SHAs to f608d3

### DIFF
--- a/actions/release/lang/ruby/notify-published/action.yml
+++ b/actions/release/lang/ruby/notify-published/action.yml
@@ -64,7 +64,7 @@ runs:
         fi
         echo "links=$LINKS" >> $GITHUB_OUTPUT
 
-    - uses: ./actions/release/notify-published
+    - uses: braintrustdata/sdk-actions/actions/release/notify-published@f608d330bca55ef04441a84cfd7f1a2358ac3575
       with:
         release_tag: ${{ inputs.release_tag }}
         prev_release: ${{ inputs.prev_release }}

--- a/actions/release/lang/ruby/on-failure/action.yml
+++ b/actions/release/lang/ruby/on-failure/action.yml
@@ -30,11 +30,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: ./actions/lang/ruby/env-dump
+    - uses: braintrustdata/sdk-actions/actions/lang/ruby/env-dump@f608d330bca55ef04441a84cfd7f1a2358ac3575
       with:
         working_directory: ${{ inputs.working_directory }}
 
-    - uses: ./actions/release/notify-failure
+    - uses: braintrustdata/sdk-actions/actions/release/notify-failure@f608d330bca55ef04441a84cfd7f1a2358ac3575
       with:
         release_tag: ${{ inputs.release_tag }}
         step: ${{ inputs.step }}

--- a/actions/release/lang/ruby/publish/action.yml
+++ b/actions/release/lang/ruby/publish/action.yml
@@ -84,7 +84,7 @@ runs:
         fetch-depth: 0
 
     - name: Push to RubyGems
-      uses: ./actions/release/lang/ruby/rubygems-push
+      uses: braintrustdata/sdk-actions/actions/release/lang/ruby/rubygems-push@f608d330bca55ef04441a84cfd7f1a2358ac3575
       with:
         working_directory: ${{ inputs.working_directory }}
         ruby_version: ${{ inputs.ruby_version }}
@@ -96,7 +96,7 @@ runs:
 
     - name: Create GitHub release
       if: ${{ inputs.github_release == 'true' }}
-      uses: ./actions/release/create-github-release
+      uses: braintrustdata/sdk-actions/actions/release/create-github-release@f608d330bca55ef04441a84cfd7f1a2358ac3575
       with:
         release_tag: ${{ inputs.release_tag }}
         sha: ${{ inputs.sha }}
@@ -104,7 +104,7 @@ runs:
         dry_run: ${{ inputs.dry_run }}
 
     - name: Notify release complete
-      uses: ./actions/release/lang/ruby/notify-published
+      uses: braintrustdata/sdk-actions/actions/release/lang/ruby/notify-published@f608d330bca55ef04441a84cfd7f1a2358ac3575
       with:
         release_tag: ${{ inputs.release_tag }}
         prev_release: ${{ inputs.prev_release }}

--- a/actions/release/lang/ruby/rubygems-push/action.yml
+++ b/actions/release/lang/ruby/rubygems-push/action.yml
@@ -57,7 +57,7 @@ runs:
 
     - name: Handle failure
       if: failure()
-      uses: ./actions/release/lang/ruby/on-failure
+      uses: braintrustdata/sdk-actions/actions/release/lang/ruby/on-failure@f608d330bca55ef04441a84cfd7f1a2358ac3575
       with:
         release_tag: ${{ inputs.release_tag }}
         step: publish

--- a/actions/release/lang/ruby/validate/action.yml
+++ b/actions/release/lang/ruby/validate/action.yml
@@ -84,7 +84,7 @@ runs:
 
     - name: Validate release
       id: validate
-      uses: ./actions/release/validate
+      uses: braintrustdata/sdk-actions/actions/release/validate@f608d330bca55ef04441a84cfd7f1a2358ac3575
       with:
         version: ${{ steps.read-version.outputs.version }}
         sha: ${{ inputs.sha }}
@@ -102,6 +102,6 @@ runs:
 
     - name: Dump Ruby environment on failure
       if: failure()
-      uses: ./actions/lang/ruby/env-dump
+      uses: braintrustdata/sdk-actions/actions/lang/ruby/env-dump@f608d330bca55ef04441a84cfd7f1a2358ac3575
       with:
         working_directory: ${{ inputs.working_directory }}

--- a/actions/release/notify-failure/action.yml
+++ b/actions/release/notify-failure/action.yml
@@ -53,7 +53,7 @@ runs:
 
     - name: Send Slack message
       if: ${{ inputs.slack_token != '' && inputs.slack_channel != '' }}
-      uses: ./actions/slack/send
+      uses: braintrustdata/sdk-actions/actions/slack/send@f608d330bca55ef04441a84cfd7f1a2358ac3575
       with:
         token: ${{ inputs.slack_token }}
         channel: ${{ inputs.slack_channel }}

--- a/actions/release/notify-pending/action.yml
+++ b/actions/release/notify-pending/action.yml
@@ -163,7 +163,7 @@ runs:
 
     - name: Send Slack message
       if: ${{ inputs.slack_token != '' && inputs.slack_channel != '' }}
-      uses: ./actions/slack/send
+      uses: braintrustdata/sdk-actions/actions/slack/send@f608d330bca55ef04441a84cfd7f1a2358ac3575
       with:
         token: ${{ inputs.slack_token }}
         channel: ${{ inputs.slack_channel }}

--- a/actions/release/notify-published/action.yml
+++ b/actions/release/notify-published/action.yml
@@ -168,7 +168,7 @@ runs:
 
     - name: Send Slack message
       if: ${{ inputs.slack_token != '' && inputs.slack_channel != '' }}
-      uses: ./actions/slack/send
+      uses: braintrustdata/sdk-actions/actions/slack/send@f608d330bca55ef04441a84cfd7f1a2358ac3575
       with:
         token: ${{ inputs.slack_token }}
         channel: ${{ inputs.slack_channel }}


### PR DESCRIPTION
Bumps the internal release action SHAs so they're stable and usable in other repos.