### PR TITLE
Add JavaScript release workflow stub

### DIFF
--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -1,0 +1,46 @@
+# Placeholder so the release-js.yml workflow_dispatch trigger is registered on the
+# default branch. This lets the full workflow be dispatched from its feature branch
+# ("Use workflow from: <branch>") before merge. The functional workflow — which
+# publishes the @braintrust/bt-fake dummy npm package end-to-end — replaces this
+# stub when the JavaScript release PR lands.
+name: Release JavaScript (@braintrust/bt-fake)
+
+on:
+  workflow_dispatch:
+    inputs:
+      _instructions:
+        description: "⚠️ Before starting: Merge a version bump PR. Version is read from the SHA."
+        type: string
+        default: "I have merged a version bump PR"
+        required: false
+      channel:
+        description: "npm release channel / dist-tag (default: latest)"
+        type: choice
+        default: latest
+        options:
+          - latest
+          - rc
+          - next
+          - beta
+      sha:
+        description: "Commit SHA (of the version bump) to release"
+        required: true
+        type: string
+      prev_release:
+        description: "Anchor for release notes: a tag name or commit SHA. If SHA, notes will be empty."
+        type: string
+        required: false
+        default: '58a397193105516446c3042361913655bcece509'
+      dry_run:
+        description: "Dry run: Build without tagging or publishing"
+        type: boolean
+        default: false
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Placeholder
+        run: echo "Placeholder — registers workflow_dispatch. The functional release-js.yml lands in the JavaScript release PR."


### PR DESCRIPTION
GitHub Actions requires a workflow to be committed to main before it can be manually triggered (registered appropriately.) In preparation for #51 , I'd like to add this stub so I can test the workflow in the branch before merging it to main.