### PR TITLE
Add package_name and release_title to release actions

### DIFF
--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -133,6 +133,7 @@ jobs:
           dry_run: ${{ inputs.dry_run || github.event_name == 'pull_request' }}
           working_directory: test/release/js
           package_manager: pnpm
+          package_name: '@braintrust/bt-publishing-test' # exercises the npm-availability fail-fast check
           channel: ${{ inputs.channel || 'latest' }}
           allowed_channels: 'latest,rc,next,beta'
 

--- a/actions/release/lang/js/publish/action.yml
+++ b/actions/release/lang/js/publish/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: "Whether to create a GitHub release"
     required: false
     default: 'true'
+  release_title:
+    description: "GitHub release name/title. Defaults to the release tag when empty."
+    required: false
+    default: ''
   npm:
     description: "Whether to publish to the npm registry"
     required: false
@@ -208,6 +212,7 @@ runs:
         ENABLED: ${{ inputs.github_release }}
         DRY_RUN: ${{ inputs.dry_run }}
         TAG: ${{ inputs.release_tag }}
+        RELEASE_TITLE: ${{ inputs.release_title }}
         NOTES_B64: ${{ inputs.notes }}
         SHA: ${{ inputs.sha }}
       run: |
@@ -215,14 +220,16 @@ runs:
           echo "GitHub release disabled; skipping."
           exit 0
         fi
+        # Release name defaults to the tag when no explicit title is provided.
+        TITLE="${RELEASE_TITLE:-$TAG}"
         if [ "$DRY_RUN" = "true" ]; then
-          echo "DRY RUN: would create GitHub release $TAG"
+          echo "DRY RUN: would create GitHub release $TAG (title: $TITLE)"
           echo "--- Release notes preview ---"
           echo "$NOTES_B64" | base64 -d 2>/dev/null || echo "(unavailable)"
         else
           echo "$NOTES_B64" | base64 -d 2>/dev/null > /tmp/release-notes.md
           gh release create "$TAG" \
-            --title "$TAG" \
+            --title "$TITLE" \
             --notes-file /tmp/release-notes.md \
             --target "$SHA"
         fi

--- a/actions/release/lang/js/validate/action.yml
+++ b/actions/release/lang/js/validate/action.yml
@@ -41,6 +41,13 @@ inputs:
     description: "npm registry URL"
     required: false
     default: 'https://registry.npmjs.org'
+  package_name:
+    description: >
+      npm package name (matches the publish action's input). When set, validate fails
+      fast if this version is already published (covers prereleases, which aren't
+      git-tagged). Leave empty to skip.
+    required: false
+    default: ''
   tag_format:
     description: "Git tag format, with a {version} placeholder (e.g. js-{version})"
     required: false
@@ -128,6 +135,23 @@ runs:
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
         fi
+
+    - name: Check npm version availability
+      shell: bash
+      env:
+        PACKAGE_NAME: ${{ inputs.package_name }}
+        VERSION: ${{ steps.read-version.outputs.version }}
+        REGISTRY: ${{ inputs.registry }}
+      run: |
+        if [ -z "$PACKAGE_NAME" ]; then
+          echo "No package_name provided; skipping npm availability check."
+          exit 0
+        fi
+        if npm view "$PACKAGE_NAME@$VERSION" version --registry "$REGISTRY" >/dev/null 2>&1; then
+          echo "Error: $PACKAGE_NAME@$VERSION already exists on npm — has the version been bumped?"
+          exit 1
+        fi
+        echo "$PACKAGE_NAME@$VERSION is available on npm."
 
     - name: Validate release channel
       shell: bash

--- a/actions/release/lang/ruby/publish/action.yml
+++ b/actions/release/lang/ruby/publish/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: "Whether to create a GitHub release"
     required: false
     default: 'true'
+  release_title:
+    description: "GitHub release name/title. Defaults to the release tag when empty."
+    required: false
+    default: ''
   notes:
     description: "Base64-encoded release notes from the prepare action"
     required: false
@@ -116,6 +120,7 @@ runs:
         ENABLED: ${{ inputs.github_release }}
         DRY_RUN: ${{ inputs.dry_run }}
         TAG: ${{ inputs.release_tag }}
+        RELEASE_TITLE: ${{ inputs.release_title }}
         NOTES_B64: ${{ inputs.notes }}
         SHA: ${{ inputs.sha }}
       run: |
@@ -123,14 +128,16 @@ runs:
           echo "GitHub release disabled; skipping."
           exit 0
         fi
+        # Release name defaults to the tag when no explicit title is provided.
+        TITLE="${RELEASE_TITLE:-$TAG}"
         if [ "$DRY_RUN" = "true" ]; then
-          echo "DRY RUN: would create GitHub release $TAG"
+          echo "DRY RUN: would create GitHub release $TAG (title: $TITLE)"
           echo "--- Release notes preview ---"
           echo "$NOTES_B64" | base64 -d 2>/dev/null || echo "(unavailable)"
         else
           echo "$NOTES_B64" | base64 -d 2>/dev/null > /tmp/release-notes.md
           gh release create "$TAG" \
-            --title "$TAG" \
+            --title "$TITLE" \
             --notes-file /tmp/release-notes.md \
             --target "$SHA"
         fi

--- a/templates/actions/release/lang/js/publish.yml.erb
+++ b/templates/actions/release/lang/js/publish.yml.erb
@@ -48,6 +48,10 @@ inputs:
     description: "Whether to create a GitHub release"
     required: false
     default: 'true'
+  release_title:
+    description: "GitHub release name/title. Defaults to the release tag when empty."
+    required: false
+    default: ''
   npm:
     description: "Whether to publish to the npm registry"
     required: false

--- a/templates/actions/release/lang/js/validate.yml.erb
+++ b/templates/actions/release/lang/js/validate.yml.erb
@@ -40,6 +40,13 @@ inputs:
     description: "npm registry URL"
     required: false
     default: 'https://registry.npmjs.org'
+  package_name:
+    description: >
+      npm package name (matches the publish action's input). When set, validate fails
+      fast if this version is already published (covers prereleases, which aren't
+      git-tagged). Leave empty to skip.
+    required: false
+    default: ''
   tag_format:
     description: "Git tag format, with a {version} placeholder (e.g. js-{version})"
     required: false
@@ -87,6 +94,8 @@ runs:
 <%= render_step('lang/js/setup') %>
 
 <%= render_step('lang/js/read-version') %>
+
+<%= render_step('release/lang/js/npm-availability') %>
 
 <%= render_step('release/lang/js/validate-channel') %>
 

--- a/templates/actions/release/lang/ruby/publish.yml.erb
+++ b/templates/actions/release/lang/ruby/publish.yml.erb
@@ -31,6 +31,10 @@ inputs:
     description: "Whether to create a GitHub release"
     required: false
     default: 'true'
+  release_title:
+    description: "GitHub release name/title. Defaults to the release tag when empty."
+    required: false
+    default: ''
   notes:
     description: "Base64-encoded release notes from the prepare action"
     required: false

--- a/templates/steps/release/create-github-release.yml.erb
+++ b/templates/steps/release/create-github-release.yml.erb
@@ -3,6 +3,7 @@
   Self-guards in shell on `github_release` (skips when disabled) and `dry_run`
   (preview vs. create), so the composing action needs no `if:` on it. Requires
   the composing action to expose github_release / dry_run / release_tag / notes / sha inputs.
+  Optionally uses release_title for the release name (defaults to the tag).
 -%>
 - name: Create GitHub release
   shell: bash
@@ -11,6 +12,7 @@
     ENABLED: ${{ inputs.github_release }}
     DRY_RUN: ${{ inputs.dry_run }}
     TAG: ${{ inputs.release_tag }}
+    RELEASE_TITLE: ${{ inputs.release_title }}
     NOTES_B64: ${{ inputs.notes }}
     SHA: ${{ inputs.sha }}
   run: |
@@ -18,14 +20,16 @@
       echo "GitHub release disabled; skipping."
       exit 0
     fi
+    # Release name defaults to the tag when no explicit title is provided.
+    TITLE="${RELEASE_TITLE:-$TAG}"
     if [ "$DRY_RUN" = "true" ]; then
-      echo "DRY RUN: would create GitHub release $TAG"
+      echo "DRY RUN: would create GitHub release $TAG (title: $TITLE)"
       echo "--- Release notes preview ---"
       echo "$NOTES_B64" | base64 -d 2>/dev/null || echo "(unavailable)"
     else
       echo "$NOTES_B64" | base64 -d 2>/dev/null > /tmp/release-notes.md
       gh release create "$TAG" \
-        --title "$TAG" \
+        --title "$TITLE" \
         --notes-file /tmp/release-notes.md \
         --target "$SHA"
     fi

--- a/templates/steps/release/lang/js/npm-availability.yml.erb
+++ b/templates/steps/release/lang/js/npm-availability.yml.erb
@@ -1,0 +1,25 @@
+<%#
+  Fails fast if the package version is already published to the npm registry.
+  Read-only registry query (no auth). Self-guards: skips when package_name is
+  empty. Complements release/validate's git-tag check by covering prereleases,
+  which aren't tagged. Assumes the read-version step (id: read-version) has run.
+
+  @param package_name [String] expr for the npm package name. Default: ${{ inputs.package_name }}
+  @param registry     [String] expr for the npm registry URL. Default: ${{ inputs.registry }}
+-%>
+- name: Check npm version availability
+  shell: bash
+  env:
+    PACKAGE_NAME: <%= locals.fetch(:package_name) { "${{ inputs.package_name }}" } %>
+    VERSION: ${{ steps.read-version.outputs.version }}
+    REGISTRY: <%= locals.fetch(:registry) { "${{ inputs.registry }}" } %>
+  run: |
+    if [ -z "$PACKAGE_NAME" ]; then
+      echo "No package_name provided; skipping npm availability check."
+      exit 0
+    fi
+    if npm view "$PACKAGE_NAME@$VERSION" version --registry "$REGISTRY" >/dev/null 2>&1; then
+      echo "Error: $PACKAGE_NAME@$VERSION already exists on npm — has the version been bumped?"
+      exit 1
+    fi
+    echo "$PACKAGE_NAME@$VERSION is available on npm."


### PR DESCRIPTION
Two small, backward-compatible ergonomics improvements to the shared release
actions, surfaced while preparing the autoevals adoption. Both default to today's
behavior, so existing consumers are unaffected.

### `release_title` (GitHub release name)

`release/create-github-release` now accepts an optional **`release_title`**, exposed
on both `release/lang/js/publish` and `release/lang/ruby/publish`. When set, it's used
as the GitHub Release name; when empty it falls back to the tag (current behavior).

Lets a consumer publish a friendly release name (e.g. `autoevals JavaScript v0.3.0`)
instead of the bare tag (`js-0.3.0`).

### npm-availability fail-fast (JS)

`release/lang/js/validate` gains an optional **`package_name`** input. When set, a new
pre-gate step fails fast if `<package_name>@<version>` is already published to npm
(read-only `npm view`, no auth).

This complements the existing git-tag-existence check, which only covers stable
releases — **prereleases aren't tagged**, so a duplicate `-rc.N` previously only failed
late at `npm publish`. Now it's caught before the approval gate.